### PR TITLE
docs: use `kubectl apply` in `Declarative Setup`

### DIFF
--- a/docs/operator-manual/declarative-setup.md
+++ b/docs/operator-manual/declarative-setup.md
@@ -1,6 +1,6 @@
 # Declarative Setup
 
-Argo CD applications, projects and settings can be defined declaratively using Kubernetes manifests.
+Argo CD applications, projects and settings can be defined declaratively using Kubernetes manifests. These can be updated using `kubectl apply`, without needing to touch the `argocd` command-line tool.
 
 ## Quick Reference
 
@@ -46,7 +46,7 @@ spec:
     namespace: guestbook
 ```
 
-See [application.yaml](application.yaml) for additional fields
+See [application.yaml](application.yaml) for additional fields. As long as you have completed the first step of [Getting Started](getting_started.md#1-install-argo-cd), you can already apply this with `kubectl apply -n argocd -f application.yaml` and Argo CD will start deploying the guestbook application.
 
 !!! note
     The namespace must match the namespace of your Argo cd, typically this is `argocd`.


### PR DESCRIPTION
The declarative setup approach is very powerful, and potentially reduces the
number of tools that you need to learn.

When coming in fresh to help out a colleague (without my head
in ops mode) my brain failed to make the mental leap from
"kubernetes manifests" to "Oh! I can use `kubectl apply` for those!".
I was worried that I would need to get kustomize out to combine things
together or something.

This patch points out that `kubectl apply` really is good enough for this job,
and also points out that it lets you skip a bunch of steps when setting up your
cluster.

Checklist:

* [ ] Either (a) I've created an [enhancement proposal](https://github.com/argoproj/argo-cd/issues/new/choose) and discussed it with the community, (b) this is a bug fix, or (c) this does not need to be in the release notes.
* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] I've updated both the CLI and UI to expose my feature, or I plan to submit a second PR with them.
* [ ] Optional. My organization is added to USERS.md.
* [ ] I've signed the CLA and my build is green ([troubleshooting builds](https://argoproj.github.io/argo-cd/developer-guide/ci/)). 
